### PR TITLE
Add fzf shell init to setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -77,7 +77,10 @@ fi
 
 # ── 4. Brew packages ──────────────────────────────────────────────────────────
 echo "==> Installing brew packages..."
-brew install kubectl helm k9s uv pre-commit lazygit python@3.12 node
+brew install kubectl helm k9s uv pre-commit lazygit python@3.12 node fzf
+
+append_line_if_missing 'eval "$(fzf --bash)"' "$HOME/.bashrc"
+append_line_if_missing 'eval "$(fzf --zsh)"' "$HOME/.zshrc"
 
 # ── 5. Node / npm CLI tools ───────────────────────────────────────────────────
 echo "==> Installing npm packages..."


### PR DESCRIPTION
## Summary
- install fzf as part of the brew package set in setup.sh
- append the bash and zsh fzf init commands to the matching shell rc files

Fixes #4